### PR TITLE
make sure the --before command line argument is respected when generating weekly updates

### DIFF
--- a/skimage_weekly_update.py
+++ b/skimage_weekly_update.py
@@ -66,41 +66,44 @@ def main():
     # We need these numbers to distinguish prs from issues
     pr_numbers = [p.number for p in pulls[:400]]
 
-    new_pulls = [pull for pull in pulls[:100] if pull.created_at >= start]
+    def in_date_range(date):
+        return date >= start and date < now
+
+    new_pulls = [pull for pull in pulls[:100] if in_date_range(pull.created_at)]
     print_list(new_pulls, 'New pull requests open last week')
 
     closed_prs = repo.get_pulls(state='closed')
 
     closed_and_not_merged_prs = [p for p in closed_prs[:200]
-            if p.merged_at is None and p.closed_at >= start ]
+            if p.merged_at is None and in_date_range(p.closed_at)]
     print_list(closed_and_not_merged_prs, 'Closed pull requests (not merged)')
 
     merged_prs = [p for p in closed_prs[:200]
-            if p.merged_at and p.merged_at >= start]
+            if p.merged_at and in_date_range(p.merged_at)]
     print_list(merged_prs, 'Merged pull requests')
 
     open_prs = repo.get_pulls(state='open')
     updated_prs = [p for p in open_prs[:100]
-            if p.created_at <= start and p.updated_at and p.updated_at >= start]
+            if p.created_at <= start and p.updated_at and in_date_range(p.updated_at)]
     print_list(updated_prs, 'Older pull requests with new comments or commits')
 
     # ------------------ Issues -------------------------------------------
     issues = repo.get_issues(since=start, state='all')
 
-    new_issues = [issue for issue in issues if issue.created_at >= start]
+    new_issues = [issue for issue in issues if in_date_range(issue.created_at)]
     new_issues = [issue for issue in new_issues
             if issue.number not in pr_numbers]
     print_list(new_issues, 'new issues')
 
     new_comments = [issue for issue in issues
-            if issue.created_at < start and issue.updated_at >= start
+            if issue.created_at < start and in_date_range(issue.updated_at)
             and issue.state == 'open']
     existing_issues_with_new_comments = [el for el in new_comments
             if el.number not in pr_numbers]
     print_list(existing_issues_with_new_comments, 'Older issues updated last week')
 
     closed_issues = [issue for issue in issues if issue.closed_at
-            and issue.closed_at >= start]
+            and in_date_range(issue.closed_at)]
     closed_issues = [issue for issue in closed_issues
             if issue.number not in pr_numbers]
     print_list(closed_issues, 'Closed issues')


### PR DESCRIPTION
Current behavior seems to be not filtering at all for the `before` date.

The issue was encountered when trying to generate a weekly update for Feb 1st through the 7th. 
`python skimage_weekly_update.py --before 2021-02-08 --after 2021-02-01`

but this was also including all issues/PRs up until the current date. After the modifications here, the report looks as expected.